### PR TITLE
promote dev to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inferencesh/sdk",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Official JavaScript/TypeScript SDK for inference.sh - Run AI models with a simple API",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -433,6 +433,13 @@ export class AgentsAPI {
   }
 
   /**
+   * Get an agent by namespace/name (e.g., "inference/my-agent")
+   */
+  async getByName(namespace: string, name: string): Promise<AgentDTO> {
+    return this.http.request<AgentDTO>('get', `/agents/${namespace}/${name}`);
+  }
+
+  /**
    * Get internal tools for the agent
    */
   async getInternalTools(): Promise<InternalToolDefinition[]> {

--- a/src/api/api-keys.ts
+++ b/src/api/api-keys.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '../http/client';
+import {
+  ApiKeyDTO,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+/**
+ * API Keys API
+ */
+export class ApiKeysAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List API keys with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<ApiKeyDTO>> {
+    return this.http.request<CursorListResponse<ApiKeyDTO>>('post', '/apikeys/list', { data: params });
+  }
+
+  /**
+   * Create an API key
+   */
+  async create(data: { name: string; scopes?: string[] }): Promise<ApiKeyDTO> {
+    return this.http.request<ApiKeyDTO>('post', '/apikeys', { data });
+  }
+
+  /**
+   * Delete an API key
+   */
+  async delete(id: string): Promise<void> {
+    return this.http.request<void>('delete', `/apikeys/${id}`);
+  }
+}

--- a/src/api/apps.test.ts
+++ b/src/api/apps.test.ts
@@ -90,7 +90,7 @@ describe('AppsAPI', () => {
 
   it('should GET /apps/{id} for get()', async () => {
     const app = { id: 'app-1', name: 'demo' };
-    mockJsonResponse({ success: true, data: app });
+    mockJsonResponse(app);
 
     const result = await api().get('app-1');
 
@@ -102,7 +102,7 @@ describe('AppsAPI', () => {
 
   it('should GET versioned app for getByVersionId()', async () => {
     const app = { id: 'app-1', version_id: 'ver-1' };
-    mockJsonResponse({ success: true, data: app });
+    mockJsonResponse(app);
 
     const result = await api().getByVersionId('app-1', 'ver-1');
 
@@ -113,7 +113,7 @@ describe('AppsAPI', () => {
 
   it('should POST /apps for create()', async () => {
     const app = { id: 'app-new', name: 'New App' };
-    mockJsonResponse({ success: true, data: app });
+    mockJsonResponse(app);
 
     const result = await api().create({ name: 'New App' });
 
@@ -126,7 +126,7 @@ describe('AppsAPI', () => {
 
   it('should POST /apps/{id} for update()', async () => {
     const app = { id: 'app-1', description: 'updated' };
-    mockJsonResponse({ success: true, data: app });
+    mockJsonResponse(app);
 
     const result = await api().update('app-1', { description: 'updated' });
 
@@ -137,7 +137,7 @@ describe('AppsAPI', () => {
   });
 
   it('should DELETE /apps/{id} for delete()', async () => {
-    mockJsonResponse({ success: true, data: null });
+    mockJsonResponse(null);
 
     await api().delete('app-1');
 
@@ -148,7 +148,7 @@ describe('AppsAPI', () => {
 
   it('should POST /apps/{id}/versions/list for listVersions()', async () => {
     const versions = { items: [{ id: 'ver-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: versions });
+    mockJsonResponse(versions);
 
     const result = await api().listVersions('app-1', { limit: 20 });
 
@@ -160,7 +160,7 @@ describe('AppsAPI', () => {
 
   it('should POST visibility for updateVisibility()', async () => {
     const app = { id: 'app-1', visibility: 'private' };
-    mockJsonResponse({ success: true, data: app });
+    mockJsonResponse(app);
 
     await api().updateVisibility('app-1', 'private');
 
@@ -170,7 +170,7 @@ describe('AppsAPI', () => {
 
   it('should GET /apps/{id}/license for getLicense()', async () => {
     const license = { app_id: 'app-1', license: 'MIT' };
-    mockJsonResponse({ success: true, data: license });
+    mockJsonResponse(license);
 
     const result = await api().getLicense('app-1');
 

--- a/src/api/chats.test.ts
+++ b/src/api/chats.test.ts
@@ -43,7 +43,7 @@ describe('ChatsAPI', () => {
 
   it('should POST /chats/list for list()', async () => {
     const page = { items: [{ id: 'chat-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().list({ limit: 25 });
 
@@ -56,7 +56,7 @@ describe('ChatsAPI', () => {
 
   it('should GET /chats/{id} for get()', async () => {
     const chat = { id: 'chat-1', status: 'open' };
-    mockJsonResponse({ success: true, data: chat });
+    mockJsonResponse(chat);
 
     const result = await api().get('chat-1');
 
@@ -68,7 +68,7 @@ describe('ChatsAPI', () => {
 
   it('should POST /chats/{id} for update()', async () => {
     const chat = { id: 'chat-1', name: 'Renamed' };
-    mockJsonResponse({ success: true, data: chat });
+    mockJsonResponse(chat);
 
     const result = await api().update('chat-1', { name: 'Renamed' });
 

--- a/src/api/chats.ts
+++ b/src/api/chats.ts
@@ -46,6 +46,27 @@ export class ChatsAPI {
   async getTrace(chatId: string): Promise<ChatTraceDTO> {
     return this.http.request<ChatTraceDTO>('get', `/chats/${chatId}/trace`);
   }
+
+  /**
+   * Get chat status
+   */
+  async getStatus(chatId: string): Promise<{ status: string }> {
+    return this.http.request<{ status: string }>('get', `/chats/${chatId}/status`);
+  }
+
+  /**
+   * Stop chat generation
+   */
+  async stop(chatId: string): Promise<void> {
+    return this.http.request<void>('post', `/chats/${chatId}/stop`);
+  }
+
+  /**
+   * Stream chat updates
+   */
+  stream(chatId: string) {
+    return this.http.createEventSource(`/chats/${chatId}/stream`);
+  }
 }
 
 export function createChatsAPI(http: HttpClient): ChatsAPI {

--- a/src/api/engines.test.ts
+++ b/src/api/engines.test.ts
@@ -71,7 +71,7 @@ describe('EnginesAPI', () => {
 
   it('should POST /engines/list for list()', async () => {
     const page = { items: [{ id: 'eng-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().list();
 
@@ -83,7 +83,7 @@ describe('EnginesAPI', () => {
 
   it('should GET /engines/{id} for get()', async () => {
     const engine = { id: 'eng-1' };
-    mockJsonResponse({ success: true, data: engine });
+    mockJsonResponse(engine);
 
     const result = await api().get('eng-1');
 
@@ -95,7 +95,7 @@ describe('EnginesAPI', () => {
 
   it('should POST /engines for create()', async () => {
     const engine = { id: 'eng-new', name: 'worker' };
-    mockJsonResponse({ success: true, data: engine });
+    mockJsonResponse(engine);
 
     const result = await api().create({ name: 'worker' });
 
@@ -108,7 +108,7 @@ describe('EnginesAPI', () => {
 
   it('should POST /engines/{id} for update()', async () => {
     const engine = { id: 'eng-1', name: 'updated' };
-    mockJsonResponse({ success: true, data: engine });
+    mockJsonResponse(engine);
 
     const result = await api().update('eng-1', { name: 'updated' });
 
@@ -118,7 +118,7 @@ describe('EnginesAPI', () => {
   });
 
   it('should DELETE /engines/{id} for delete()', async () => {
-    mockJsonResponse({ success: true, data: null });
+    mockJsonResponse(null);
 
     await api().delete('eng-1');
 
@@ -129,7 +129,7 @@ describe('EnginesAPI', () => {
 
   it('should POST visibility for updateVisibility()', async () => {
     const engine = { id: 'eng-1', visibility: 'team' };
-    mockJsonResponse({ success: true, data: engine });
+    mockJsonResponse(engine);
 
     await api().updateVisibility('eng-1', 'team');
 
@@ -139,7 +139,7 @@ describe('EnginesAPI', () => {
 
   it('should POST transfer with team_id for transferOwnership()', async () => {
     const engine = { id: 'eng-1' };
-    mockJsonResponse({ success: true, data: engine });
+    mockJsonResponse(engine);
 
     await api().transferOwnership('eng-1', 'team-7');
 

--- a/src/api/engines.ts
+++ b/src/api/engines.ts
@@ -101,6 +101,13 @@ export class EnginesAPI {
   async drain(engineId: string): Promise<void> {
     return this.http.request<void>('post', `/engines/${engineId}/drain`);
   }
+
+  /**
+   * Update an engine binary (drain + restart with new version)
+   */
+  async updateBinary(engineId: string): Promise<void> {
+    return this.http.request<void>('post', `/engines/${engineId}/update`);
+  }
 }
 
 export function createEnginesAPI(http: HttpClient): EnginesAPI {

--- a/src/api/engines.ts
+++ b/src/api/engines.ts
@@ -87,6 +87,20 @@ export class EnginesAPI {
   async transferOwnership(engineId: string, newTeamId: string): Promise<Engine> {
     return this.http.request<Engine>('post', `/engines/${engineId}/transfer`, { data: { team_id: newTeamId } });
   }
+
+  /**
+   * Extend engine duration
+   */
+  async extend(engineId: string): Promise<void> {
+    return this.http.request<void>('post', `/engines/${engineId}/extend`);
+  }
+
+  /**
+   * Drain an engine
+   */
+  async drain(engineId: string): Promise<void> {
+    return this.http.request<void>('post', `/engines/${engineId}/drain`);
+  }
 }
 
 export function createEnginesAPI(http: HttpClient): EnginesAPI {

--- a/src/api/files.test.ts
+++ b/src/api/files.test.ts
@@ -75,6 +75,51 @@ describe('FilesAPI', () => {
       expect(putCall[1]?.headers).toMatchObject({ 'Content-Type': 'text/plain' });
     });
 
+    it('should default media type to text/plain for data URIs without explicit type', async () => {
+      const fileRecord = {
+        id: 'file-4',
+        uri: 'inf://files/default-mt',
+        upload_url: 'https://upload.example.com/put',
+        content_type: 'text/plain',
+      };
+
+      mockJsonResponse([fileRecord]);
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+
+      await api().upload('data:;base64,SGVsbG8=');
+
+      const putCall = mockFetch.mock.calls[1];
+      expect(putCall[1]?.headers).toMatchObject({ 'Content-Type': 'text/plain' });
+    });
+
+    it('should throw when server does not return upload_url', async () => {
+      mockJsonResponse([{ id: 'file-x', uri: '', upload_url: undefined }]);
+
+      await expect(api().upload('data:text/plain,hello')).rejects.toThrow(
+        'No upload URL provided by the server'
+      );
+    });
+
+    it('should throw when PUT to upload_url fails', async () => {
+      const fileRecord = {
+        id: 'file-5',
+        uri: 'inf://files/fail-put',
+        upload_url: 'https://upload.example.com/put',
+        content_type: 'text/plain',
+      };
+
+      mockJsonResponse([fileRecord]);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      await expect(api().upload('data:text/plain,hello')).rejects.toThrow(
+        'Failed to upload file content'
+      );
+    });
+
     it('should decode URL-safe base64 in data URIs', async () => {
       const fileRecord = {
         id: 'file-2',

--- a/src/api/flow-runs.test.ts
+++ b/src/api/flow-runs.test.ts
@@ -71,7 +71,7 @@ describe('FlowRunsAPI', () => {
 
   it('should POST /flowruns/list for list()', async () => {
     const page = { items: [{ id: 'fr-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().list({ limit: 10 });
 
@@ -83,7 +83,7 @@ describe('FlowRunsAPI', () => {
 
   it('should GET /flowruns/{id} for get()', async () => {
     const flowRun = { id: 'fr-1' };
-    mockJsonResponse({ success: true, data: flowRun });
+    mockJsonResponse(flowRun);
 
     const result = await api().get('fr-1');
 
@@ -95,7 +95,7 @@ describe('FlowRunsAPI', () => {
 
   it('should POST /flowruns/{id}/clone for clone()', async () => {
     const flowRun = { id: 'fr-clone' };
-    mockJsonResponse({ success: true, data: flowRun });
+    mockJsonResponse(flowRun);
 
     const result = await api().clone('fr-1');
 
@@ -107,7 +107,7 @@ describe('FlowRunsAPI', () => {
 
   it('should POST /flowruns/{id} for update()', async () => {
     const flowRun = { id: 'fr-1', fail_on_error: false };
-    mockJsonResponse({ success: true, data: flowRun });
+    mockJsonResponse(flowRun);
 
     const result = await api().update('fr-1', { fail_on_error: false });
 
@@ -118,7 +118,7 @@ describe('FlowRunsAPI', () => {
 
   it('should POST visibility for updateVisibility()', async () => {
     const flowRun = { id: 'fr-1', visibility: 'public' };
-    mockJsonResponse({ success: true, data: flowRun });
+    mockJsonResponse(flowRun);
 
     await api().updateVisibility('fr-1', 'public');
 

--- a/src/api/flows.test.ts
+++ b/src/api/flows.test.ts
@@ -56,7 +56,7 @@ describe('FlowsAPI', () => {
 
   it('should POST /flows/list for list()', async () => {
     const page = { items: [{ id: 'flow-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().list({ limit: 10 });
 
@@ -68,7 +68,7 @@ describe('FlowsAPI', () => {
 
   it('should GET /flows/{id} for get()', async () => {
     const flow = { id: 'flow-1', name: 'Demo' };
-    mockJsonResponse({ success: true, data: flow });
+    mockJsonResponse(flow);
 
     const result = await api().get('flow-1');
 
@@ -80,7 +80,7 @@ describe('FlowsAPI', () => {
 
   it('should POST /flows/{id} for update()', async () => {
     const flow = { id: 'flow-1', name: 'Renamed' };
-    mockJsonResponse({ success: true, data: flow });
+    mockJsonResponse(flow);
 
     const result = await api().update('flow-1', { name: 'Renamed' });
 
@@ -90,7 +90,7 @@ describe('FlowsAPI', () => {
   });
 
   it('should DELETE /flows/{id} for delete()', async () => {
-    mockJsonResponse({ success: true, data: null });
+    mockJsonResponse(null);
 
     await api().delete('flow-1');
 
@@ -101,7 +101,7 @@ describe('FlowsAPI', () => {
 
   it('should POST /flows/{id}/duplicate for duplicate()', async () => {
     const flow = { id: 'flow-copy' };
-    mockJsonResponse({ success: true, data: flow });
+    mockJsonResponse(flow);
 
     const result = await api().duplicate('flow-1');
 
@@ -112,7 +112,7 @@ describe('FlowsAPI', () => {
 
   it('should POST /flows/{id}/versions/list for listVersions()', async () => {
     const versions = { items: [{ id: 'ver-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: versions });
+    mockJsonResponse(versions);
 
     const result = await api().listVersions('flow-1');
 
@@ -123,7 +123,7 @@ describe('FlowsAPI', () => {
 
   it('should POST transfer with team_id for transferOwnership()', async () => {
     const flow = { id: 'flow-1' };
-    mockJsonResponse({ success: true, data: flow });
+    mockJsonResponse(flow);
 
     await api().transferOwnership('flow-1', 'team-42');
 

--- a/src/api/integrations.ts
+++ b/src/api/integrations.ts
@@ -1,0 +1,72 @@
+import { HttpClient } from '../http/client';
+import {
+  IntegrationDTO,
+  IntegrationConfigDTO,
+  IntegrationConnectRequest,
+  IntegrationConnectResponse,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+/**
+ * Integrations API
+ */
+export class IntegrationsAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List integrations with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<IntegrationDTO>> {
+    return this.http.request<CursorListResponse<IntegrationDTO>>('post', '/integrations/list', { data: params });
+  }
+
+  /**
+   * Get available integrations
+   */
+  async listAvailable(): Promise<IntegrationConfigDTO[]> {
+    return this.http.request<IntegrationConfigDTO[]>('get', '/integrations/available');
+  }
+
+  /**
+   * Get integration configs
+   */
+  async getConfigs(): Promise<IntegrationConfigDTO[]> {
+    return this.http.request<IntegrationConfigDTO[]>('get', '/integrations/configs');
+  }
+
+  /**
+   * Get capabilities
+   */
+  async getCapabilities(): Promise<unknown> {
+    return this.http.request<unknown>('get', '/integrations/capabilities');
+  }
+
+  /**
+   * Check requirements
+   */
+  async checkRequirements(data: unknown): Promise<unknown> {
+    return this.http.request<unknown>('post', '/integrations/check', { data });
+  }
+
+  /**
+   * Connect an integration
+   */
+  async connect(data: IntegrationConnectRequest): Promise<IntegrationConnectResponse> {
+    return this.http.request<IntegrationConnectResponse>('post', '/integrations', { data });
+  }
+
+  /**
+   * Get an integration by provider key
+   */
+  async get(provider: string): Promise<IntegrationDTO> {
+    return this.http.request<IntegrationDTO>('get', `/integrations/${provider}`);
+  }
+
+  /**
+   * Disconnect an integration
+   */
+  async disconnect(provider: string): Promise<void> {
+    return this.http.request<void>('delete', `/integrations/${provider}`);
+  }
+}

--- a/src/api/knowledge.ts
+++ b/src/api/knowledge.ts
@@ -1,0 +1,195 @@
+import { HttpClient } from '../http/client';
+import {
+  KnowledgeDTO,
+  KnowledgeVersionDTO,
+  KnowledgeCreateRequest,
+  SkillDTO,
+  SkillVersionDTO,
+  CursorListRequest,
+  CursorListResponse,
+  PublicSkillStoreDTO,
+} from '../types';
+
+/**
+ * Knowledge API
+ */
+export class KnowledgeAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List knowledge entries with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<KnowledgeDTO>> {
+    return this.http.request<CursorListResponse<KnowledgeDTO>>('post', '/knowledge/list', { data: params });
+  }
+
+  /**
+   * Get a knowledge entry by ID
+   */
+  async get(id: string): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('get', `/knowledge/${id}`);
+  }
+
+  /**
+   * Get a knowledge entry by namespace/name
+   */
+  async getByName(namespace: string, name: string): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('get', `/knowledge/${namespace}/${name}`);
+  }
+
+  /**
+   * Create a knowledge entry
+   */
+  async create(data: KnowledgeCreateRequest): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('post', '/knowledge', { data });
+  }
+
+  /**
+   * Update a knowledge entry
+   */
+  async update(id: string, data: Partial<KnowledgeDTO>): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('post', `/knowledge/${id}`, { data });
+  }
+
+  /**
+   * Delete a knowledge entry
+   */
+  async delete(id: string): Promise<void> {
+    return this.http.request<void>('delete', `/knowledge/${id}`);
+  }
+
+  /**
+   * List knowledge versions
+   */
+  async listVersions(id: string, params?: Partial<CursorListRequest>): Promise<CursorListResponse<KnowledgeVersionDTO>> {
+    return this.http.request<CursorListResponse<KnowledgeVersionDTO>>('post', `/knowledge/${id}/versions/list`, { data: params });
+  }
+
+  /**
+   * Get a specific version
+   */
+  async getVersion(id: string, versionId: string): Promise<KnowledgeVersionDTO> {
+    return this.http.request<KnowledgeVersionDTO>('get', `/knowledge/${id}/versions/${versionId}`);
+  }
+
+  /**
+   * Transfer ownership
+   */
+  async transferOwnership(id: string, newTeamId: string): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('post', `/knowledge/${id}/transfer`, { data: { team_id: newTeamId } });
+  }
+
+  /**
+   * Update visibility
+   */
+  async updateVisibility(id: string, visibility: string): Promise<KnowledgeDTO> {
+    return this.http.request<KnowledgeDTO>('post', `/knowledge/${id}/visibility`, { data: { visibility } });
+  }
+}
+
+/**
+ * Skills API
+ */
+export class SkillsAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List skills with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<SkillDTO>> {
+    return this.http.request<CursorListResponse<SkillDTO>>('post', '/skills/list', { data: params });
+  }
+
+  /**
+   * Get a skill by ID
+   */
+  async get(id: string): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('get', `/skills/${id}`);
+  }
+
+  /**
+   * Get a skill by namespace/name
+   */
+  async getByName(namespace: string, name: string): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('get', `/skills/${namespace}/${name}`);
+  }
+
+  /**
+   * Resolve a skill (store + GitHub fallback)
+   */
+  async resolve(ref: string, skill?: string): Promise<unknown> {
+    const params: Record<string, string> = { ref };
+    if (skill) params.skill = skill;
+    return this.http.request<unknown>('get', '/skills/resolve', { params });
+  }
+
+  /**
+   * Create/publish a skill
+   */
+  async create(data: Partial<SkillDTO>): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('post', '/skills', { data });
+  }
+
+  /**
+   * Update a skill
+   */
+  async update(id: string, data: Partial<SkillDTO>): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('post', `/skills/${id}`, { data });
+  }
+
+  /**
+   * Delete a skill
+   */
+  async delete(id: string): Promise<void> {
+    return this.http.request<void>('delete', `/skills/${id}`);
+  }
+
+  /**
+   * List skill versions
+   */
+  async listVersions(id: string, params?: Partial<CursorListRequest>): Promise<CursorListResponse<SkillVersionDTO>> {
+    return this.http.request<CursorListResponse<SkillVersionDTO>>('post', `/skills/${id}/versions/list`, { data: params });
+  }
+
+  /**
+   * Get a specific skill version
+   */
+  async getVersion(id: string, versionId: string): Promise<SkillVersionDTO> {
+    return this.http.request<SkillVersionDTO>('get', `/skills/${id}/versions/${versionId}`);
+  }
+
+  /**
+   * Download a skill
+   */
+  async download(namespace: string, name: string): Promise<unknown> {
+    return this.http.request<unknown>('get', `/skills/${namespace}/${name}/download`);
+  }
+
+  /**
+   * Get skill content
+   */
+  async getContent(namespace: string, name: string): Promise<unknown> {
+    return this.http.request<unknown>('get', `/skills/${namespace}/${name}/content`);
+  }
+
+  /**
+   * Transfer ownership
+   */
+  async transferOwnership(id: string, newTeamId: string): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('post', `/skills/${id}/transfer`, { data: { team_id: newTeamId } });
+  }
+
+  /**
+   * Update visibility
+   */
+  async updateVisibility(id: string, visibility: string): Promise<SkillDTO> {
+    return this.http.request<SkillDTO>('post', `/skills/${id}/visibility`, { data: { visibility } });
+  }
+
+  /**
+   * List skills in the public store
+   */
+  async listStore(params?: Partial<CursorListRequest>): Promise<CursorListResponse<PublicSkillStoreDTO>> {
+    return this.http.request<CursorListResponse<PublicSkillStoreDTO>>('post', '/store/skills/list', { data: params });
+  }
+}

--- a/src/api/mcp-servers.ts
+++ b/src/api/mcp-servers.ts
@@ -1,0 +1,76 @@
+import { HttpClient } from '../http/client';
+import {
+  MCPServerDTO,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+/**
+ * MCP Servers API
+ */
+export class MCPServersAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List public MCP servers
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<MCPServerDTO>> {
+    return this.http.request<CursorListResponse<MCPServerDTO>>('post', '/mcps/list', { data: params });
+  }
+
+  /**
+   * Get an MCP server by slug
+   */
+  async get(slug: string): Promise<MCPServerDTO> {
+    return this.http.request<MCPServerDTO>('get', `/mcps/${slug}`);
+  }
+
+  /**
+   * List tools for an MCP server
+   */
+  async listTools(slug: string): Promise<unknown[]> {
+    return this.http.request<unknown[]>('get', `/mcps/${slug}/tools`);
+  }
+
+  /**
+   * Call a tool on an MCP server
+   */
+  async callTool(slug: string, tool: string, input: unknown): Promise<unknown> {
+    return this.http.request<unknown>('post', `/mcps/${slug}/tools/${tool}`, { data: input });
+  }
+
+  /**
+   * List user's own MCP servers
+   */
+  async listOwned(params?: Partial<CursorListRequest>): Promise<CursorListResponse<MCPServerDTO>> {
+    return this.http.request<CursorListResponse<MCPServerDTO>>('post', '/mcp-servers/list', { data: params });
+  }
+
+  /**
+   * Get a user's MCP server by ID
+   */
+  async getOwned(id: string): Promise<MCPServerDTO> {
+    return this.http.request<MCPServerDTO>('get', `/mcp-servers/${id}`);
+  }
+
+  /**
+   * Create an MCP server
+   */
+  async create(data: Partial<MCPServerDTO>): Promise<MCPServerDTO> {
+    return this.http.request<MCPServerDTO>('post', '/mcp-servers', { data });
+  }
+
+  /**
+   * Update an MCP server
+   */
+  async update(id: string, data: Partial<MCPServerDTO>): Promise<MCPServerDTO> {
+    return this.http.request<MCPServerDTO>('put', `/mcp-servers/${id}`, { data });
+  }
+
+  /**
+   * Delete an MCP server
+   */
+  async delete(id: string): Promise<void> {
+    return this.http.request<void>('delete', `/mcp-servers/${id}`);
+  }
+}

--- a/src/api/projects.ts
+++ b/src/api/projects.ts
@@ -1,0 +1,48 @@
+import { HttpClient } from '../http/client';
+import {
+  ProjectDTO,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+/**
+ * Projects API
+ */
+export class ProjectsAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List projects with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<ProjectDTO>> {
+    return this.http.request<CursorListResponse<ProjectDTO>>('post', '/projects/list', { data: params });
+  }
+
+  /**
+   * Get a project by ID
+   */
+  async get(id: string): Promise<ProjectDTO> {
+    return this.http.request<ProjectDTO>('get', `/projects/${id}`);
+  }
+
+  /**
+   * Create a project
+   */
+  async create(data: Partial<ProjectDTO>): Promise<ProjectDTO> {
+    return this.http.request<ProjectDTO>('post', '/projects', { data });
+  }
+
+  /**
+   * Update a project
+   */
+  async update(id: string, data: Partial<ProjectDTO>): Promise<ProjectDTO> {
+    return this.http.request<ProjectDTO>('post', `/projects/${id}`, { data });
+  }
+
+  /**
+   * Delete a project
+   */
+  async delete(id: string): Promise<void> {
+    return this.http.request<void>('delete', `/projects/${id}`);
+  }
+}

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '../http/client';
+import {
+  SuggestRequest,
+  SuggestResponse,
+} from '../types';
+
+/**
+ * Search API
+ */
+export class SearchAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * Unified search across skills, knowledge, and apps
+   */
+  async suggest(params: Partial<SuggestRequest>): Promise<SuggestResponse> {
+    return this.http.request<SuggestResponse>('post', '/suggest', { data: params });
+  }
+
+  /**
+   * Full-text search via Meilisearch
+   */
+  async search(params: { q: string; type?: string; limit?: number }): Promise<unknown> {
+    return this.http.request<unknown>('post', '/search', { data: params });
+  }
+}

--- a/src/api/secrets.ts
+++ b/src/api/secrets.ts
@@ -1,0 +1,49 @@
+import { HttpClient } from '../http/client';
+import {
+  SecretDTO,
+  SecretCreateRequest,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+/**
+ * Secrets API
+ */
+export class SecretsAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * List secrets with cursor-based pagination
+   */
+  async list(params?: Partial<CursorListRequest>): Promise<CursorListResponse<SecretDTO>> {
+    return this.http.request<CursorListResponse<SecretDTO>>('post', '/secrets/list', { data: params });
+  }
+
+  /**
+   * Create a secret
+   */
+  async create(data: SecretCreateRequest): Promise<SecretDTO> {
+    return this.http.request<SecretDTO>('post', '/secrets', { data });
+  }
+
+  /**
+   * Update a secret
+   */
+  async update(key: string, data: Partial<SecretCreateRequest>): Promise<SecretDTO> {
+    return this.http.request<SecretDTO>('put', `/secrets/${key}`, { data });
+  }
+
+  /**
+   * Delete a secret
+   */
+  async delete(key: string): Promise<void> {
+    return this.http.request<void>('delete', `/secrets/${key}`);
+  }
+
+  /**
+   * Reveal a secret value
+   */
+  async reveal(key: string): Promise<SecretDTO> {
+    return this.http.request<SecretDTO>('get', `/secrets/reveal/${key}`);
+  }
+}

--- a/src/api/tasks.test.ts
+++ b/src/api/tasks.test.ts
@@ -120,6 +120,27 @@ describe('TasksAPI.run (polling mode)', () => {
     ).rejects.toThrow('status endpoint down');
   });
 
+  it('should not refetch full task when poll status is unchanged', async () => {
+    const runningTask = makeTask();
+    const completedTask = makeTask({ status: TaskStatusCompleted, output: { ok: true } });
+
+    mockJsonResponse(runningTask);
+    mockJsonResponse({ status: TaskStatusRunning });
+    mockJsonResponse({ status: TaskStatusRunning });
+    mockJsonResponse({ status: TaskStatusCompleted });
+    mockJsonResponse(completedTask);
+
+    await api().run({ app: 'test-app', input: {} }, {}, { wait: true, stream: false });
+
+    const fullTaskGets = mockFetch.mock.calls.filter(
+      ([url, init]) =>
+        String(url).includes('/tasks/task-1') &&
+        !String(url).includes('/status') &&
+        (init as RequestInit).method === 'GET'
+    );
+    expect(fullTaskGets).toHaveLength(1);
+  });
+
   it('should parse string terminal statuses from the status endpoint', async () => {
     const runningTask = makeTask();
     const completedTask = makeTask({ status: TaskStatusCompleted });
@@ -285,6 +306,30 @@ describe('TasksAPI.run (streaming mode)', () => {
   });
 });
 
+describe('TasksAPI.create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const api = () => new TasksAPI(new HttpClient({ apiKey: 'test-key' }));
+
+  it('should POST /apps/run for create()', async () => {
+    const task = makeTask();
+    mockJsonResponse(task);
+
+    const result = await api().create({ app: 'test-app', input: { prompt: 'hi' } });
+
+    expect(result).toEqual(task);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/apps/run');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      app: 'test-app',
+      input: { prompt: 'hi' },
+    });
+  });
+});
+
 describe('TasksAPI (CRUD and admin)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -294,7 +339,7 @@ describe('TasksAPI (CRUD and admin)', () => {
 
   it('should POST /tasks/list for list()', async () => {
     const page = { items: [{ id: 'task-1' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().list({ limit: 5 });
 
@@ -307,7 +352,7 @@ describe('TasksAPI (CRUD and admin)', () => {
 
   it('should GET /tasks/featured for listFeatured()', async () => {
     const page = { items: [{ id: 'task-f' }], next_cursor: null };
-    mockJsonResponse({ success: true, data: page });
+    mockJsonResponse(page);
 
     const result = await api().listFeatured({ cursor: 'abc' });
 
@@ -319,7 +364,7 @@ describe('TasksAPI (CRUD and admin)', () => {
 
   it('should GET /tasks/{id} for get()', async () => {
     const task = makeTask();
-    mockJsonResponse({ success: true, data: task });
+    mockJsonResponse(task);
 
     const result = await api().get('task-1');
 
@@ -330,7 +375,7 @@ describe('TasksAPI (CRUD and admin)', () => {
   });
 
   it('should DELETE /tasks/{id} for delete()', async () => {
-    mockJsonResponse({ success: true, data: null });
+    mockJsonResponse(null);
 
     await api().delete('task-1');
 
@@ -340,7 +385,7 @@ describe('TasksAPI (CRUD and admin)', () => {
   });
 
   it('should POST /tasks/{id}/cancel for cancel()', async () => {
-    mockJsonResponse({ success: true, data: null });
+    mockJsonResponse(null);
 
     await api().cancel('task-1');
 
@@ -351,7 +396,7 @@ describe('TasksAPI (CRUD and admin)', () => {
 
   it('should POST visibility for updateVisibility()', async () => {
     const task = makeTask({ visibility: 'public' });
-    mockJsonResponse({ success: true, data: task });
+    mockJsonResponse(task);
 
     const result = await api().updateVisibility('task-1', 'public');
 
@@ -362,7 +407,7 @@ describe('TasksAPI (CRUD and admin)', () => {
 
   it('should POST is_featured for feature()', async () => {
     const task = makeTask({ is_featured: true });
-    mockJsonResponse({ success: true, data: task });
+    mockJsonResponse(task);
 
     await api().feature('task-1', true);
 

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -262,8 +262,8 @@ export class TasksAPI {
   /**
    * Get task telemetry
    */
-  async getTelemetry(taskId: string): Promise<unknown> {
-    return this.http.request<unknown>('get', `/tasks/${taskId}/telemetry`);
+  async getTelemetry(taskId: string): Promise<Record<string, unknown>[]> {
+    return this.http.request<Record<string, unknown>[]>('get', `/tasks/${taskId}/telemetry`);
   }
 }
 

--- a/src/api/tasks.ts
+++ b/src/api/tasks.ts
@@ -3,6 +3,8 @@ import { StreamableManager } from '../http/streamable';
 import { PollManager } from '../http/poll';
 import {
   TaskDTO as Task,
+  TaskLogsDTO,
+  TaskTimingsDTO,
   ResourceStatusDTO,
   ApiAppRunRequest,
   TaskStatusCompleted,
@@ -241,6 +243,27 @@ export class TasksAPI {
    */
   async feature(taskId: string, featured: boolean): Promise<Task> {
     return this.http.request<Task>('post', `/tasks/${taskId}/featured`, { data: { is_featured: featured } });
+  }
+
+  /**
+   * Get task logs
+   */
+  async getLogs(taskId: string): Promise<TaskLogsDTO> {
+    return this.http.request<TaskLogsDTO>('get', `/tasks/${taskId}/logs`);
+  }
+
+  /**
+   * Get task timings
+   */
+  async getTimings(taskId: string): Promise<TaskTimingsDTO> {
+    return this.http.request<TaskTimingsDTO>('get', `/tasks/${taskId}/timings`);
+  }
+
+  /**
+   * Get task telemetry
+   */
+  async getTelemetry(taskId: string): Promise<unknown> {
+    return this.http.request<unknown>('get', `/tasks/${taskId}/telemetry`);
   }
 }
 

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,0 +1,122 @@
+import { HttpClient } from '../http/client';
+import {
+  UserDTO,
+  TeamRelationDTO,
+  TeamMemberDTO,
+  TeamInviteDTO,
+  TeamCreateRequest,
+  TeamMemberAddRequest,
+  TeamInviteCreateRequest,
+  CursorListRequest,
+  CursorListResponse,
+} from '../types';
+
+export interface MeResponse {
+  user: UserDTO;
+  team?: TeamRelationDTO;
+}
+
+/**
+ * Teams API
+ */
+export class TeamsAPI {
+  constructor(private readonly http: HttpClient) { }
+
+  /**
+   * Get current user and team context
+   */
+  async me(): Promise<MeResponse> {
+    return this.http.request<MeResponse>('get', '/me');
+  }
+
+  /**
+   * List user's teams
+   */
+  async list(): Promise<TeamRelationDTO[]> {
+    return this.http.request<TeamRelationDTO[]>('get', '/teams');
+  }
+
+  /**
+   * Get a team by ID
+   */
+  async get(teamId: string): Promise<TeamRelationDTO> {
+    return this.http.request<TeamRelationDTO>('get', `/teams/${teamId}`);
+  }
+
+  /**
+   * Create a new team
+   */
+  async create(data: TeamCreateRequest): Promise<TeamRelationDTO> {
+    return this.http.request<TeamRelationDTO>('post', '/teams', { data });
+  }
+
+  /**
+   * Update a team
+   */
+  async update(teamId: string, data: Partial<TeamCreateRequest>): Promise<TeamRelationDTO> {
+    return this.http.request<TeamRelationDTO>('post', `/teams/${teamId}`, { data });
+  }
+
+  /**
+   * Delete a team
+   */
+  async delete(teamId: string): Promise<void> {
+    return this.http.request<void>('delete', `/teams/${teamId}`);
+  }
+
+  /**
+   * Check username availability
+   */
+  async checkUsername(username: string): Promise<{ available: boolean }> {
+    return this.http.request<{ available: boolean }>('get', '/teams/check-username', { params: { username } });
+  }
+
+  /**
+   * Get team members
+   */
+  async getMembers(teamId: string): Promise<TeamMemberDTO[]> {
+    return this.http.request<TeamMemberDTO[]>('get', `/teams/${teamId}/members`);
+  }
+
+  /**
+   * Add a team member
+   */
+  async addMember(teamId: string, data: TeamMemberAddRequest): Promise<TeamMemberDTO> {
+    return this.http.request<TeamMemberDTO>('post', `/teams/${teamId}/members`, { data });
+  }
+
+  /**
+   * Remove a team member
+   */
+  async removeMember(teamId: string, userId: string): Promise<void> {
+    return this.http.request<void>('delete', `/teams/${teamId}/members/${userId}`);
+  }
+
+  /**
+   * Update a member's role
+   */
+  async updateMemberRole(teamId: string, userId: string, role: string): Promise<TeamMemberDTO> {
+    return this.http.request<TeamMemberDTO>('post', `/teams/${teamId}/members/${userId}/role`, { data: { role } });
+  }
+
+  /**
+   * List team invites
+   */
+  async listInvites(teamId: string): Promise<TeamInviteDTO[]> {
+    return this.http.request<TeamInviteDTO[]>('get', `/teams/${teamId}/invites`);
+  }
+
+  /**
+   * Create an invite
+   */
+  async createInvite(teamId: string, data: TeamInviteCreateRequest): Promise<TeamInviteDTO> {
+    return this.http.request<TeamInviteDTO>('post', `/teams/${teamId}/invites`, { data });
+  }
+
+  /**
+   * Revoke an invite
+   */
+  async revokeInvite(teamId: string, inviteId: string): Promise<void> {
+    return this.http.request<void>('delete', `/teams/${teamId}/invites/${inviteId}`);
+  }
+}

--- a/src/http/client.test.ts
+++ b/src/http/client.test.ts
@@ -166,6 +166,17 @@ describe('HttpClient', () => {
       });
     });
 
+    it('should use getToken for Authorization on regular requests', async () => {
+      mockJsonResponse({ id: 'task-1' });
+
+      const tokenClient = new HttpClient({ getToken: () => 'dynamic-key' });
+      await tokenClient.request('get', '/tasks/task-1');
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer dynamic-key');
+    });
+
     it('should send X-API-Version 2 and X-Client-Source on every request', async () => {
       mockJsonResponse({ id: 'task-1' });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,14 @@ export { ChatsAPI } from './api/chats';
 export { FlowsAPI } from './api/flows';
 export { FlowRunsAPI } from './api/flow-runs';
 export { EnginesAPI } from './api/engines';
+export { KnowledgeAPI, SkillsAPI } from './api/knowledge';
+export { TeamsAPI, MeResponse } from './api/teams';
+export { SecretsAPI } from './api/secrets';
+export { ApiKeysAPI } from './api/api-keys';
+export { IntegrationsAPI } from './api/integrations';
+export { SearchAPI } from './api/search';
+export { ProjectsAPI } from './api/projects';
+export { MCPServersAPI } from './api/mcp-servers';
 
 // Tool Builder (fluent API)
 export {
@@ -72,6 +80,14 @@ import { ChatsAPI } from './api/chats';
 import { FlowsAPI } from './api/flows';
 import { FlowRunsAPI } from './api/flow-runs';
 import { EnginesAPI } from './api/engines';
+import { KnowledgeAPI, SkillsAPI } from './api/knowledge';
+import { TeamsAPI } from './api/teams';
+import { SecretsAPI } from './api/secrets';
+import { ApiKeysAPI } from './api/api-keys';
+import { IntegrationsAPI } from './api/integrations';
+import { SearchAPI } from './api/search';
+import { ProjectsAPI } from './api/projects';
+import { MCPServersAPI } from './api/mcp-servers';
 import { ApiAppRunRequest, TaskDTO as Task, AgentConfigInput as AgentConfig, FileDTO as File } from './types';
 
 export interface InferenceConfig {
@@ -115,6 +131,15 @@ export class Inference {
   readonly flows: FlowsAPI;
   readonly flowRuns: FlowRunsAPI;
   readonly engines: EnginesAPI;
+  readonly knowledge: KnowledgeAPI;
+  readonly skills: SkillsAPI;
+  readonly teams: TeamsAPI;
+  readonly secrets: SecretsAPI;
+  readonly apiKeys: ApiKeysAPI;
+  readonly integrations: IntegrationsAPI;
+  readonly search: SearchAPI;
+  readonly projects: ProjectsAPI;
+  readonly mcpServers: MCPServersAPI;
 
   constructor(config: InferenceConfig | HttpClientConfig) {
     // Handle both simple config and full HttpClientConfig
@@ -138,6 +163,15 @@ export class Inference {
     this.flows = new FlowsAPI(this.http);
     this.flowRuns = new FlowRunsAPI(this.http);
     this.engines = new EnginesAPI(this.http);
+    this.knowledge = new KnowledgeAPI(this.http);
+    this.skills = new SkillsAPI(this.http);
+    this.teams = new TeamsAPI(this.http);
+    this.secrets = new SecretsAPI(this.http);
+    this.apiKeys = new ApiKeysAPI(this.http);
+    this.integrations = new IntegrationsAPI(this.http);
+    this.search = new SearchAPI(this.http);
+    this.projects = new ProjectsAPI(this.http);
+    this.mcpServers = new MCPServersAPI(this.http);
   }
 
   // Legacy methods for backward compatibility


### PR DESCRIPTION
## Summary
- 6 commits: telemetry types, engines.updateBinary(), test coverage

## Test plan
- CI passes on dev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive API surface and test/mock changes around response parsing could surprise integrators; secrets, API keys, and engine lifecycle calls touch security- and ops-sensitive endpoints.
> 
> **Overview**
> **Release 0.6.11** broadens the JS SDK so the main `Inference` client exposes several new first-class APIs (knowledge/skills, teams, secrets, API keys, integrations, search, projects, MCP servers), each as thin HTTP wrappers aligned with the backend routes.
> 
> Existing modules gain targeted endpoints: **agents** `getByName`, **chats** status/stop/stream, **engines** extend/drain/`updateBinary`, **tasks** logs/timings/telemetry. Unit tests now mock **direct JSON bodies** instead of legacy `{ success, data }` envelopes, matching API v2 client behavior.
> 
> **Behavior and quality:** task **wait/poll** skips full task GETs when status is unchanged; **files** upload tests cover missing `upload_url`, failed PUT, and default content-type for bare data URIs; **HttpClient** tests assert **`getToken`** is used for `Authorization` on normal requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68090ef69441749a723ebc61b423adf2c2713c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->